### PR TITLE
Fix empty global causing exception

### DIFF
--- a/tpParser/shared/src/main/scala/tigerpython/parser/parsing/ExpressionParser.scala
+++ b/tpParser/shared/src/main/scala/tigerpython/parser/parsing/ExpressionParser.scala
@@ -163,10 +163,12 @@ class ExpressionParser(val parser: Parser, val parserState: ParserState) {
 
   def parseNameList(tokens: TokenBuffer): Array[AstNode.Name] = {
     val result = ArrayBuffer[AstNode.Name]()
-    val startPos = tokens.head.pos
-    while (tokens.hasType(TokenType.NAME)) {
-      result += AstNode.Name(startPos, tokens.next().value)
-      tokens.matchType(TokenType.COMMA)
+    if (tokens.head != null) {
+      val startPos = tokens.head.pos
+      while (tokens.hasType(TokenType.NAME)) {
+        result += AstNode.Name(startPos, tokens.next().value)
+        tokens.matchType(TokenType.COMMA)
+      }
     }
     if (result.isEmpty)
       parserState.reportError(tokens, ErrorCode.NAME_EXPECTED)

--- a/tpParser/shared/src/test/programs/erroneous/empty_global_01.txt
+++ b/tpParser/shared/src/test/programs/erroneous/empty_global_01.txt
@@ -1,0 +1,4 @@
+# 2
+# NAME_EXPECTED
+def func(arg=0.1):
+    global


### PR DESCRIPTION
See #11 -- global keyword followed by nothing causes an exception.  This simple PR adds a test proving the issue, and then a fix which makes the test work.  (I'm not sure if NAME_EXPECTED is the most suitable error, but it was the one given if you have a trailing comma with nothing after, so it seemed like a reasonable choice.)

Fixes #11