### PR TITLE
Fix code completion on lists and dicts

### DIFF
--- a/tpParser/shared/src/main/scala/tigerpython/parser/types/TypeAstWalker.scala
+++ b/tpParser/shared/src/main/scala/tigerpython/parser/types/TypeAstWalker.scala
@@ -65,6 +65,10 @@ class TypeAstWalker {
         getTypeOfList(list)
       case list: AstNode.ListComp =>
         getTypeOfListComp(list)
+      case _: AstNode.Dict =>
+        BuiltinTypes.DICT
+      case _dict: AstNode.DictComp =>
+        BuiltinTypes.DICT
       case name: AstNode.Name =>
         validateDataType(findName(name.name))
       case subscript: AstNode.Subscript =>

--- a/tpParser/shared/src/main/scala/tigerpython/utilities/types/BuiltinTypes.scala
+++ b/tpParser/shared/src/main/scala/tigerpython/utilities/types/BuiltinTypes.scala
@@ -221,12 +221,6 @@ object BuiltinTypes {
         "to None, so that this method never raises a KeyError."),
     BuiltinFunction("items", Array(), LIST_TYPE,
       "Return a copy of the dictionary’s list of (key, value) pairs."),
-    BuiltinFunction("iteritems", Array(), ITERATOR_TYPE,
-      "Return an iterator over the dictionary’s (key, value) pairs."),
-    BuiltinFunction("iterkeys", Array(), ITERATOR_TYPE,
-      "Return an iterator over the dictionary’s keys."),
-    BuiltinFunction("itervalues", Array(), ITERATOR_TYPE,
-      "Return an iterator over the dictionary’s values."),
     BuiltinFunction("keys", Array(), LIST_TYPE,
       "Return a copy of the dictionary’s list of keys."),
     BuiltinFunction("pop", Array("key", "default"), ANY_TYPE,
@@ -240,13 +234,7 @@ object BuiltinTypes {
     BuiltinFunction("update", Array("other"), NONE_TYPE,
       "Update the dictionary with the key/value pairs from other, overwriting existing keys. Return None."),
     BuiltinFunction("values", Array(), LIST_TYPE,
-      "Return a copy of the dictionary’s list of values."),
-    BuiltinFunction("viewitems", Array(), ANY_TYPE,
-      "Return a new view of the dictionary’s items ((key, value) pairs)."),
-    BuiltinFunction("viewkeys", Array(), ANY_TYPE,
-      "Return a new view of the dictionary’s keys."),
-    BuiltinFunction("viewvalues", Array(), ANY_TYPE,
-      "Return a new view of the dictionary’s values.")
+      "Return a copy of the dictionary’s list of values.")
   )
 
   val FILE_TYPE = PrimitiveType("file", Map(

--- a/tpParser/shared/src/main/scala/tigerpython/utilities/types/BuiltinTypes.scala
+++ b/tpParser/shared/src/main/scala/tigerpython/utilities/types/BuiltinTypes.scala
@@ -103,12 +103,6 @@ object BuiltinTypes {
     BuiltinFunction("sort", Array(), MUTABLE_SEQ, "sort the items of the sequence in place")
   )
   val LIST_TYPE = PrimitiveType("list", MUTABLE_SEQ)
-  LIST_TYPE.addFields(
-    PrimitiveType("first"),
-    PrimitiveType("head"),
-    PrimitiveType("last"),
-    PrimitiveType("tail", LIST_TYPE)
-  )
   val TUPLE_TYPE = PrimitiveType("tuple", SEQ_TYPE)
   val BYTEARRAY_TYPE = PrimitiveType("bytearray", SEQ_TYPE)
   val BUFFER_TYPE = PrimitiveType("buffer", SEQ_TYPE)

--- a/tpParser/shared/src/main/scala/tigerpython/utilities/types/TypeAstWalker.scala
+++ b/tpParser/shared/src/main/scala/tigerpython/utilities/types/TypeAstWalker.scala
@@ -169,7 +169,7 @@ class TypeAstWalker {
       for (element <- list.elements)
         result = DataType.getCompatibleType(result, getType(element))
       if (result != null && result != ANY_TYPE)
-        Instance(ListType(result))
+        new Instance(ListType(result))
       else
         BuiltinTypes.LIST
     } else

--- a/tpParser/shared/src/main/scala/tigerpython/utilities/types/TypeAstWalker.scala
+++ b/tpParser/shared/src/main/scala/tigerpython/utilities/types/TypeAstWalker.scala
@@ -57,6 +57,10 @@ class TypeAstWalker {
         getTypeOfList(list)
       case list: AstNode.ListComp =>
         getTypeOfListComp(list)
+      case _: AstNode.Dict =>
+        BuiltinTypes.DICT
+      case _: AstNode.DictComp =>
+        BuiltinTypes.DICT
       case name: AstNode.Name =>
         validateDataType(findName(name.name))
       case subscript: AstNode.Subscript =>

--- a/tpParser/shared/src/test/programs/completer/completer_example_4.py
+++ b/tpParser/shared/src/test/programs/completer/completer_example_4.py
@@ -1,0 +1,4 @@
+# 18
+# append;count;extend;index;insert;pop;remove;reverse;sort
+li = [1,2,3,4]
+li.append(5)

--- a/tpParser/shared/src/test/programs/completer/completer_example_5.py
+++ b/tpParser/shared/src/test/programs/completer/completer_example_5.py
@@ -1,0 +1,16 @@
+# 243
+# draw;extent;pos_x;pos_y
+class Shape:
+
+    def __init__(self, x, y):
+        self.pos_x = x
+        self.pos_y = y
+
+    def draw(self):
+        pass
+
+    def extent(self):
+        return (0, 0)
+
+myshape = [Shape(123, 456), Shape(123, 456), Shape(123, 456)]
+myshape[0].draw()

--- a/tpParser/shared/src/test/programs/completer/completer_example_6.py
+++ b/tpParser/shared/src/test/programs/completer/completer_example_6.py
@@ -1,0 +1,4 @@
+# 19
+# clear;copy;get;items;keys;pop;popitem;setdefault;update;values
+dt = {1:2, 3:4}
+dt.clear()


### PR DESCRIPTION
We discovered that code completion doesn't work on list and dict types, so here's a couple of commits to fix that.  I'm not 100% sure about the first one (changing Instance to new Instance), so worth looking at.  I also fixed some superfluous (in Python 3) items being shown on those types.